### PR TITLE
Make WooCommerce hooks pluggable

### DIFF
--- a/inc/addons.php
+++ b/inc/addons.php
@@ -89,9 +89,12 @@ function chronus_infinite_scroll_render() {
 /**
  * Set wrapper start for wooCommerce
  */
-function chronus_wrapper_start() {
-	echo '<section id="primary" class="content-area">';
-	echo '<main id="main" class="site-main" role="main">';
+if (!function_exists('chronus_wrapper_start')) {
+    function chronus_wrapper_start()
+    {
+        echo '<section id="primary" class="fullwidth-content-area content-area">';
+        echo '<main id="main" class="site-main" role="main">';
+    }
 }
 remove_action( 'woocommerce_before_main_content', 'woocommerce_output_content_wrapper', 10 );
 add_action( 'woocommerce_before_main_content', 'chronus_wrapper_start', 10 );
@@ -100,9 +103,12 @@ add_action( 'woocommerce_before_main_content', 'chronus_wrapper_start', 10 );
 /**
  * Set wrapper end for wooCommerce
  */
-function chronus_wrapper_end() {
-	echo '</main><!-- #main -->';
-	echo '</section><!-- #primary -->';
+if (!function_exists('chronus_wrapper_end')) {
+    function chronus_wrapper_end()
+    {
+        echo '</main><!-- #main -->';
+        echo '</section><!-- #primary -->';
+    }
 }
 remove_action( 'woocommerce_after_main_content', 'woocommerce_output_content_wrapper_end', 10 );
 add_action( 'woocommerce_after_main_content', 'chronus_wrapper_end', 10 );


### PR DESCRIPTION
By making the WooCommerce hooks pluggable functions it's possible to control the layout in a child theme.